### PR TITLE
fix: resolve ESLint errors blocking Netlify production build

### DIFF
--- a/src/app/api/stripe/cancel/route.js
+++ b/src/app/api/stripe/cancel/route.js
@@ -4,7 +4,7 @@ import { stripe } from "@/libs/stripe";
 import prisma from "@/libs/prisma";
 import { checkoutLimiter } from "@/libs/rate-limit";
 
-export async function POST(req) {
+export async function POST() {
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) {

--- a/src/app/api/videos/route.js
+++ b/src/app/api/videos/route.js
@@ -3,7 +3,7 @@ import { authOptions } from "@/libs/auth";
 import prisma from "@/libs/prisma";
 import { generalLimiter } from "@/libs/rate-limit";
 
-export async function GET(req) {
+export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -5,8 +5,8 @@ import { useEffect, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import {
-  Upload, Video, Sparkles, Crown, ArrowRight,
-  BarChart3, Settings, Clock, ExternalLink, Film,
+  Upload, Video, Sparkles, Crown,
+  Clock, ExternalLink, Film,
   Plus, TrendingUp
 } from 'lucide-react';
 import Link from 'next/link';

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -8,7 +8,7 @@ export default function NotFound() {
         <p className="text-7xl font-bold gradient-text mb-4">404</p>
         <h1 className="text-2xl font-bold mb-2">Page not found</h1>
         <p className="text-sm text-white/50 mb-8">
-          The page you're looking for doesn't exist or has been moved.
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
         </p>
         <Link href="/" className="btn-primary inline-flex">
           <Home className="w-4 h-4" /> Back to home

--- a/src/components/KeyboardShortcuts.js
+++ b/src/components/KeyboardShortcuts.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Keyboard, X } from 'lucide-react';
 

--- a/src/components/OpenSourceSection.js
+++ b/src/components/OpenSourceSection.js
@@ -82,8 +82,8 @@ export default function OpenSourceSection() {
               <p><span className="text-brand-300">payments</span>  <span className="text-white/20">→</span> Stripe Subscriptions</p>
               <p><span className="text-brand-300">styling</span>  <span className="text-white/20">→</span> Tailwind CSS</p>
               <p><span className="text-brand-300">deploy</span>  <span className="text-white/20">→</span> Netlify / Vercel</p>
-              <p className="mt-3 text-white/15">// everything is inspectable at</p>
-              <p className="text-white/15">// github.com/ParthMadhvani2/FramePhase</p>
+              <p className="mt-3 text-white/15">{"// everything is inspectable at"}</p>
+              <p className="text-white/15">{"// github.com/ParthMadhvani2/FramePhase"}</p>
             </div>
           </motion.div>
         </div>

--- a/src/components/ResultVideo.js
+++ b/src/components/ResultVideo.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { transcriptionItemsToSrt } from "@/libs/awsTranscriptionHelpers";
-import { getAvailablePresets, canAccess } from "@/libs/plans";
+import { getAvailablePresets } from "@/libs/plans";
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { toBlobURL, fetchFile } from "@ffmpeg/util";
 import { useEffect, useState, useRef, useCallback } from "react";
@@ -10,7 +10,6 @@ import { Sparkles, Download, Lock, ChevronDown, ArrowUpRight } from "lucide-reac
 import FramePhaseLoader from "@/components/FramePhaseLoader";
 import Link from "next/link";
 import toast from "react-hot-toast";
-import { UpgradeBadge } from "./LockedFeature";
 import poppins from './../fonts/Poppins-Regular.ttf';
 import poppinsBold from './../fonts/Poppins-Bold.ttf';
 

--- a/src/components/UploadForm.js
+++ b/src/components/UploadForm.js
@@ -173,7 +173,6 @@ export default function UploadForm() {
   };
 
   const isUploading = uploadQueue.some(q => q.status === 'uploading' || q.status === 'pending');
-  const activeUpload = uploadQueue.find(q => q.status === 'uploading');
   const selectedLang = SUPPORTED_LANGUAGES.find(l => l.code === selectedLanguage);
 
   return (

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -21,7 +21,7 @@ export const authOptions = {
     strategy: "jwt",
   },
   callbacks: {
-    async jwt({ token, user, trigger }) {
+    async jwt({ token, user }) {
       // On first sign-in, set admin privileges if applicable
       if (user) {
         const isAdmin = ADMIN_EMAILS.includes(user.email?.toLowerCase());

--- a/src/libs/prisma.js
+++ b/src/libs/prisma.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { PrismaClient } from '@prisma/client';
 
 const globalForPrisma = globalThis;


### PR DESCRIPTION
- Remove unused req param from stripe/cancel and videos API routes
- Remove unused lucide-react imports from dashboard (ArrowRight, BarChart3, Settings)
- Escape apostrophes in not-found page (react/no-unescaped-entities)
- Remove unused useState import from KeyboardShortcuts
- Wrap JSX comment text in braces in OpenSourceSection
- Remove unused canAccess and UpgradeBadge imports from ResultVideo
- Remove unused activeUpload variable in UploadForm
- Remove unused trigger param from auth jwt callback
- Disable no-undef for globalThis in prisma singleton