### PR TITLE
perf: speed up landing page and fix favicon mismatch

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="logoBg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#4f46e5" />
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#logoBg)" />
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="none" stroke="white" stroke-opacity="0.15" stroke-width="0.5" />
+  <path d="M13 10.5V21.5L22 16L13 10.5Z" fill="white" fill-opacity="0.95" />
+  <rect x="8" y="24" width="7" height="1.5" rx="0.75" fill="white" fill-opacity="0.5" />
+  <rect x="17" y="24" width="7" height="1.5" rx="0.75" fill="white" fill-opacity="0.3" />
+</svg>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -30,7 +30,10 @@ export const metadata = {
     creator: "@ParthMadhvani2",
   },
   icons: {
-    icon: "/favicon.ico",
+    icon: [
+      { url: "/favicon.svg", type: "image/svg+xml" },
+      { url: "/favicon.ico", sizes: "any" },
+    ],
     apple: "/apple-icon.png",
   },
   robots: {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,11 +1,15 @@
+import dynamic from "next/dynamic";
 import HeroSection from "@/components/HeroSection";
-import FeaturesSection from "@/components/FeaturesSection";
-import HowItWorksSection from "@/components/HowItWorksSection";
-import ComparisonSection from "@/components/ComparisonSection";
-import TrustSection from "@/components/TrustSection";
-import CTASection from "@/components/CTASection";
-import FAQSection from "@/components/FAQSection";
-import Footer from "@/components/Footer";
+
+// Below-the-fold sections are lazy-loaded to speed up initial paint.
+// Hero stays in the main bundle since it's always above the fold.
+const FeaturesSection = dynamic(() => import("@/components/FeaturesSection"));
+const HowItWorksSection = dynamic(() => import("@/components/HowItWorksSection"));
+const ComparisonSection = dynamic(() => import("@/components/ComparisonSection"));
+const TrustSection = dynamic(() => import("@/components/TrustSection"));
+const CTASection = dynamic(() => import("@/components/CTASection"));
+const FAQSection = dynamic(() => import("@/components/FAQSection"));
+const Footer = dynamic(() => import("@/components/Footer"));
 
 // Structured data for SEO — helps Google show rich results
 const jsonLd = {

--- a/src/components/HeroSection.js
+++ b/src/components/HeroSection.js
@@ -155,7 +155,7 @@ export default function HeroSection() {
                     src="https://dawid-epic-captions.s3.us-east-1.amazonaws.com/without-captions.mp4"
                     crossOrigin="anonymous"
                     muted loop playsInline
-                    preload="auto"
+                    preload="metadata"
                     className="w-full h-full object-cover"
                   />
                 </div>
@@ -168,7 +168,7 @@ export default function HeroSection() {
                     src="https://dawid-epic-captions.s3.us-east-1.amazonaws.com/with-captions.mp4"
                     crossOrigin="anonymous"
                     muted loop playsInline
-                    preload="auto"
+                    preload="metadata"
                     className="w-full h-full object-cover"
                   />
                 </div>


### PR DESCRIPTION
- Lazy-load below-fold sections (Features, HowItWorks, Comparison, Trust, CTA, FAQ, Footer) via next/dynamic so the hero paints immediately
- Change hero before/after videos from preload=auto to preload=metadata to avoid downloading the entire video files on initial load (biggest perf win)
- Add matching SVG favicon that mirrors the navbar Logo component (indigo gradient, play triangle, caption lines); modern browsers prefer SVG, falls back to .ico for older ones
- Update layout.js icons metadata to prefer favicon.svg