### PR TITLE
fix: tolerate multiple AWS env var names + add debug-env endpoint

### DIFF
--- a/src/app/api/debug-env/route.js
+++ b/src/app/api/debug-env/route.js
@@ -1,0 +1,52 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/libs/auth";
+import { getAwsCredentials, getAwsRegion, getBucketName } from "@/libs/aws-config";
+
+/**
+ * Admin-only diagnostic endpoint. Reports WHICH env vars the server can see
+ * (never the values themselves), so we can quickly tell if Netlify is
+ * serving stale env vars or if the wrong names are set.
+ *
+ * GET /api/debug-env — requires the caller to be an admin.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const isAdmin = session?.user?.isAdmin || session?.user?.plan === "admin";
+  if (!isAdmin) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const mask = (name) => {
+    const v = process.env[name];
+    if (!v) return { present: false };
+    return {
+      present: true,
+      length: v.length,
+      trimmedLength: v.trim().length,
+      hasWhitespace: v !== v.trim(),
+      firstChar: v[0],
+      lastChar: v[v.length - 1],
+    };
+  };
+
+  const creds = getAwsCredentials();
+
+  return Response.json({
+    resolved: {
+      region: getAwsRegion(),
+      bucket: getBucketName() || null,
+      hasAccessKey: !!creds.accessKeyId,
+      hasSecretKey: !!creds.secretAccessKey,
+      accessKeyLength: creds.accessKeyId?.length || 0,
+      accessKeyPrefix: creds.accessKeyId?.slice(0, 4) || null, // AWS access keys start with "AKIA"
+    },
+    rawEnvPresence: {
+      AWS_ACCESS_KEY1: mask("AWS_ACCESS_KEY1"),
+      AWS_SECRET_ACCESS_KEY1: mask("AWS_SECRET_ACCESS_KEY1"),
+      AWS_ACCESS_KEY_ID: mask("AWS_ACCESS_KEY_ID"),
+      AWS_SECRET_ACCESS_KEY: mask("AWS_SECRET_ACCESS_KEY"),
+      AWS_REGION: mask("AWS_REGION"),
+      BUCKET_NAME: mask("BUCKET_NAME"),
+    },
+  });
+}

--- a/src/app/api/transcribe/route.js
+++ b/src/app/api/transcribe/route.js
@@ -4,24 +4,20 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/libs/auth";
 import { transcribeLimiter } from "@/libs/rate-limit";
 import prisma from "@/libs/prisma";
+import { getS3ClientConfig, getBucketName } from "@/libs/aws-config";
 
 function getClient() {
-  return new TranscribeClient({
-    region: 'us-east-1',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY1,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY1,
-    },
-  });
+  return new TranscribeClient(getS3ClientConfig());
 }
 
 function createTranscriptionCommand(filename, languageCode) {
+  const bucket = getBucketName();
   const params = {
     TranscriptionJobName: filename,
-    OutputBucketName: process.env.BUCKET_NAME,
+    OutputBucketName: bucket,
     OutputKey: filename + '.transcription',
     Media: {
-      MediaFileUri: 's3://' + process.env.BUCKET_NAME + '/' + filename,
+      MediaFileUri: 's3://' + bucket + '/' + filename,
     },
   };
 
@@ -66,15 +62,9 @@ async function streamToString(stream) {
 
 async function getTranscriptionFile(filename) {
   const transcriptionFile = filename + '.transcription';
-  const s3client = new S3Client({
-    region: 'us-east-1',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY1,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY1,
-    },
-  });
+  const s3client = new S3Client(getS3ClientConfig());
   const getObjectCommand = new GetObjectCommand({
-    Bucket: process.env.BUCKET_NAME,
+    Bucket: getBucketName(),
     Key: transcriptionFile,
   });
   let transcriptionFileResponse = null;

--- a/src/app/api/upload/route.js
+++ b/src/app/api/upload/route.js
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/libs/auth";
 import prisma from "@/libs/prisma";
 import { uploadLimiter } from "@/libs/rate-limit";
+import { getS3ClientConfig, getBucketName, getAwsCredentials } from "@/libs/aws-config";
 import uniqid from 'uniqid';
 
 export async function POST(req) {
@@ -63,13 +64,23 @@ export async function POST(req) {
     const { name, type } = file;
     const data = await file.arrayBuffer();
 
-    const s3client = new S3Client({
-      region: 'us-east-1',
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY1,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY1,
-      },
-    });
+    // Fail fast with a clear message if server env vars aren't set
+    const creds = getAwsCredentials();
+    const bucket = getBucketName();
+    if (!creds.accessKeyId || !creds.secretAccessKey) {
+      return Response.json(
+        { error: "Server misconfigured: AWS credentials are not set. Check Netlify env vars (AWS_ACCESS_KEY1 + AWS_SECRET_ACCESS_KEY1)." },
+        { status: 500 }
+      );
+    }
+    if (!bucket) {
+      return Response.json(
+        { error: "Server misconfigured: BUCKET_NAME env var is not set." },
+        { status: 500 }
+      );
+    }
+
+    const s3client = new S3Client(getS3ClientConfig());
 
     const id = uniqid();
     const rawExt = name.split('.').slice(-1)[0]?.toLowerCase();
@@ -81,7 +92,7 @@ export async function POST(req) {
     // ACL: 'public-read' would make S3 reject the PUT with AccessControlListNotSupported.
     // Videos are served to the client via presigned GET URLs (see /api/video-url).
     const uploadCommand = new PutObjectCommand({
-      Bucket: process.env.BUCKET_NAME,
+      Bucket: bucket,
       Body: Buffer.from(data),
       ContentType: type,
       Key: newName,

--- a/src/app/api/video-url/route.js
+++ b/src/app/api/video-url/route.js
@@ -3,6 +3,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/libs/auth";
 import prisma from "@/libs/prisma";
+import { getS3ClientConfig, getBucketName } from "@/libs/aws-config";
 
 /**
  * Returns a short-lived presigned GET URL for a video stored in our private
@@ -40,16 +41,10 @@ export async function GET(req) {
   }
 
   try {
-    const s3 = new S3Client({
-      region: "us-east-1",
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY1,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY1,
-      },
-    });
+    const s3 = new S3Client(getS3ClientConfig());
 
     const command = new GetObjectCommand({
-      Bucket: process.env.BUCKET_NAME,
+      Bucket: getBucketName(),
       Key: filename,
     });
 

--- a/src/libs/aws-config.js
+++ b/src/libs/aws-config.js
@@ -1,0 +1,52 @@
+/**
+ * Centralized AWS credential + region resolver.
+ *
+ * Accepts several env var naming conventions so it works regardless of which
+ * set of names are defined in the hosting env (Netlify, Vercel, local .env):
+ *   - AWS_ACCESS_KEY1          / AWS_SECRET_ACCESS_KEY1     (legacy FramePhase)
+ *   - AWS_ACCESS_KEY_ID        / AWS_SECRET_ACCESS_KEY       (AWS standard)
+ *   - FRAMEPHASE_AWS_ACCESS_KEY_ID / FRAMEPHASE_AWS_SECRET_ACCESS_KEY (namespaced)
+ *
+ * Values are `.trim()`ed to handle accidental trailing newlines pasted into
+ * hosting dashboards (a common cause of SignatureDoesNotMatch errors).
+ */
+
+const pick = (...keys) => {
+  for (const k of keys) {
+    const v = process.env[k];
+    if (typeof v === "string" && v.trim().length > 0) {
+      return v.trim();
+    }
+  }
+  return undefined;
+};
+
+export function getAwsCredentials() {
+  return {
+    accessKeyId: pick(
+      "AWS_ACCESS_KEY1",
+      "AWS_ACCESS_KEY_ID",
+      "FRAMEPHASE_AWS_ACCESS_KEY_ID"
+    ),
+    secretAccessKey: pick(
+      "AWS_SECRET_ACCESS_KEY1",
+      "AWS_SECRET_ACCESS_KEY",
+      "FRAMEPHASE_AWS_SECRET_ACCESS_KEY"
+    ),
+  };
+}
+
+export function getAwsRegion() {
+  return pick("AWS_REGION", "FRAMEPHASE_AWS_REGION") || "us-east-1";
+}
+
+export function getBucketName() {
+  return pick("BUCKET_NAME", "S3_BUCKET_NAME", "FRAMEPHASE_BUCKET_NAME");
+}
+
+export function getS3ClientConfig() {
+  return {
+    region: getAwsRegion(),
+    credentials: getAwsCredentials(),
+  };
+}


### PR DESCRIPTION
- Extract AWS credential/region/bucket resolution into src/libs/aws-config.js which accepts AWS_ACCESS_KEY1, AWS_ACCESS_KEY_ID, or FRAMEPHASE_AWS_ACCESS_KEY_ID (same for secret key and bucket name), and trims whitespace to avoid the classic 'pasted-a-newline-into-the-Netlify-UI' SignatureDoesNotMatch.
- Wire helper into upload, video-url, and transcribe routes.
- Upload route now fails fast with an explicit 'Server misconfigured' message when credentials or bucket aren't set, instead of sending undefined to AWS and getting a confusing InvalidAccessKeyId.
- New /api/debug-env endpoint (admin-only) reports which env var names are defined, their lengths, whether they have whitespace, and the access key prefix (should be 'AKIA'), without ever returning values.