### PR TITLE
fix: apply captions CORS + better error messages

### DIFF
--- a/aws/s3-cors.json
+++ b/aws/s3-cors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedOrigins": [
+      "https://frame-phase.netlify.app",
+      "http://localhost:3000"
+    ],
+    "ExposeHeaders": ["ETag", "Content-Length", "Content-Type"],
+    "MaxAgeSeconds": 3000
+  }
+]

--- a/src/components/ResultVideo.js
+++ b/src/components/ResultVideo.js
@@ -160,7 +160,29 @@ export default function ResultVideo({ filename, transcriptionItems }) {
     try {
       setIsProcessing(true);
       const srt = transcriptionItemsToSrt(transcriptionItems);
-      await ffmpeg.writeFile(filename, await fetchFile(videoUrl));
+
+      // Fetch the video ourselves so we can distinguish CORS / network errors
+      // from ffmpeg decode errors. fetchFile() swallows fetch errors into a
+      // generic "failed to load" message, which is unhelpful in prod.
+      let videoBytes;
+      try {
+        const res = await fetch(videoUrl, { mode: 'cors' });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status} ${res.statusText}`);
+        }
+        videoBytes = new Uint8Array(await res.arrayBuffer());
+      } catch (fetchErr) {
+        // Most common cause: S3 bucket has no CORS policy, so the browser
+        // blocks the cross-origin fetch with a TypeError "Failed to fetch".
+        const isCors = fetchErr instanceof TypeError;
+        throw new Error(
+          isCors
+            ? 'Browser blocked the video download (CORS). The S3 bucket needs a CORS policy allowing GET from this domain.'
+            : `Failed to download video: ${fetchErr.message}`
+        );
+      }
+
+      await ffmpeg.writeFile(filename, videoBytes);
       await ffmpeg.writeFile('subs.srt', srt);
       videoRef.current.src = videoUrl;
       await new Promise((resolve, reject) => {
@@ -192,7 +214,8 @@ export default function ResultVideo({ filename, transcriptionItems }) {
       toast.success('Captions applied!');
     } catch (error) {
       console.error('Transcoding failed:', error);
-      toast.error('Failed to apply captions. Please try again.');
+      // Surface the actual error message so the user (and we) can debug
+      toast.error(error?.message || 'Failed to apply captions. Please try again.', { duration: 6000 });
       setProgress(1);
     } finally {
       setIsProcessing(false);
@@ -346,7 +369,7 @@ export default function ResultVideo({ filename, transcriptionItems }) {
             </div>
           </div>
         )}
-        <video ref={videoRef} controls className="w-full" />
+        <video ref={videoRef} crossOrigin="anonymous" controls className="w-full" />
       </div>
 
       {/* Caption Preview Label */}


### PR DESCRIPTION
- Replace fetchFile() with an explicit fetch() in the transcode path so CORS / network errors surface as a clear 'Browser blocked the video download (CORS)' toast instead of the generic 'Failed to apply captions'. fetchFile swallows the underlying TypeError which made this impossible to diagnose in prod.
- Add crossOrigin='anonymous' to the preview <video> so the HTML5 player and ffmpeg.wasm share a single CORS-aware cache entry for the presigned S3 URL (without this, Chrome caches a non-CORS copy from the preview and then refuses the CORS-enabled fetch from ffmpeg).
- Pass the actual error message through to the toast with a 6s duration so the user can read it.
- Add aws/s3-cors.json with the bucket CORS policy to apply: allows GET/HEAD from frame-phase.netlify.app and localhost:3000.