### PR TITLE
fix: revert crossOrigin on video tag + add /api/video-proxy fallback

### DIFF
--- a/src/app/api/video-proxy/route.js
+++ b/src/app/api/video-proxy/route.js
@@ -1,0 +1,68 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/libs/auth";
+import prisma from "@/libs/prisma";
+import { getS3ClientConfig, getBucketName } from "@/libs/aws-config";
+
+/**
+ * Streams a video from the private S3 bucket through our server so the
+ * browser doesn't need to hit S3 directly. This is a CORS workaround for
+ * buckets without a CORS policy, but it routes ALL video bytes through
+ * Netlify Functions — only viable for small videos (up to ~10 MB).
+ *
+ * For larger files the user should configure an S3 CORS policy and use
+ * /api/video-url (presigned GET URL) directly.
+ *
+ * GET /api/video-proxy?filename=<newName>
+ */
+export async function GET(req) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const filename = searchParams.get("filename");
+
+  if (!filename || !/^[a-zA-Z0-9_.-]+$/.test(filename)) {
+    return Response.json({ error: "Invalid filename" }, { status: 400 });
+  }
+
+  // Ownership check — same as /api/video-url
+  const video = await prisma.video.findFirst({
+    where: { filename },
+    select: { userId: true },
+  });
+  if (!video) {
+    return Response.json({ error: "Video not found" }, { status: 404 });
+  }
+  const isAdmin = session.user.isAdmin || session.user.plan === "admin";
+  if (video.userId !== session.user.id && !isAdmin) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const s3 = new S3Client(getS3ClientConfig());
+    const command = new GetObjectCommand({
+      Bucket: getBucketName(),
+      Key: filename,
+    });
+    const s3Response = await s3.send(command);
+
+    // Stream the body straight through to the browser
+    return new Response(s3Response.Body, {
+      status: 200,
+      headers: {
+        "Content-Type": s3Response.ContentType || "video/mp4",
+        "Content-Length": String(s3Response.ContentLength || ""),
+        "Cache-Control": "private, max-age=3600",
+      },
+    });
+  } catch (error) {
+    console.error("Video proxy error:", error);
+    return Response.json(
+      { error: `Failed to stream video: ${error?.message || "unknown"}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/ResultVideo.js
+++ b/src/components/ResultVideo.js
@@ -161,25 +161,33 @@ export default function ResultVideo({ filename, transcriptionItems }) {
       setIsProcessing(true);
       const srt = transcriptionItemsToSrt(transcriptionItems);
 
-      // Fetch the video ourselves so we can distinguish CORS / network errors
-      // from ffmpeg decode errors. fetchFile() swallows fetch errors into a
-      // generic "failed to load" message, which is unhelpful in prod.
+      // Fetch the video bytes for ffmpeg. Try the direct presigned S3 URL
+      // first (fast, no server cost), and if the S3 bucket has no CORS
+      // policy the browser will throw a TypeError — fall back to our
+      // same-origin proxy route which streams the bytes through the server.
       let videoBytes;
-      try {
-        const res = await fetch(videoUrl, { mode: 'cors' });
+      const tryFetch = async (url, label) => {
+        const res = await fetch(url);
         if (!res.ok) {
-          throw new Error(`HTTP ${res.status} ${res.statusText}`);
+          throw new Error(`${label} returned HTTP ${res.status} ${res.statusText}`);
         }
-        videoBytes = new Uint8Array(await res.arrayBuffer());
-      } catch (fetchErr) {
-        // Most common cause: S3 bucket has no CORS policy, so the browser
-        // blocks the cross-origin fetch with a TypeError "Failed to fetch".
-        const isCors = fetchErr instanceof TypeError;
-        throw new Error(
-          isCors
-            ? 'Browser blocked the video download (CORS). The S3 bucket needs a CORS policy allowing GET from this domain.'
-            : `Failed to download video: ${fetchErr.message}`
-        );
+        return new Uint8Array(await res.arrayBuffer());
+      };
+
+      try {
+        videoBytes = await tryFetch(videoUrl, 'S3');
+      } catch (directErr) {
+        console.warn('Direct S3 fetch failed, falling back to proxy:', directErr);
+        try {
+          videoBytes = await tryFetch(
+            `/api/video-proxy?filename=${encodeURIComponent(filename)}`,
+            'Proxy'
+          );
+        } catch (proxyErr) {
+          throw new Error(
+            `Failed to download video. S3 direct: ${directErr.message}. Proxy: ${proxyErr.message}`
+          );
+        }
       }
 
       await ffmpeg.writeFile(filename, videoBytes);
@@ -369,7 +377,7 @@ export default function ResultVideo({ filename, transcriptionItems }) {
             </div>
           </div>
         )}
-        <video ref={videoRef} crossOrigin="anonymous" controls className="w-full" />
+        <video ref={videoRef} controls className="w-full" />
       </div>
 
       {/* Caption Preview Label */}


### PR DESCRIPTION
- Remove crossOrigin='anonymous' from the <video> preview element. That attribute makes the browser demand CORS headers even for basic playback, so without an S3 CORS policy the preview wouldn't load at all (regression from the previous commit).
- Add /api/video-proxy that streams the S3 object through our Next.js server, so it's same-origin and bypasses CORS entirely. Suitable for small videos (<10 MB Netlify function response limit).
- Transcode flow now tries the direct presigned S3 URL first (fast, zero server cost), and falls back to the proxy route if the direct fetch throws a CORS TypeError. This means Apply Captions will work today even without the bucket CORS policy, at least for small reels.
- Final error message includes both failure modes so the user can tell whether the direct path or the proxy path failed.