### PR TITLE
fix: consistent avatar, better AI summary, unstick ffmpeg loading

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,14 +26,19 @@ const nextConfig = {
           { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
         ],
       },
-      // COEP/COOP only on the video editor page — FFmpeg WASM needs SharedArrayBuffer.
-      // Applying globally blocks cross-origin resources (S3 videos, Google OAuth popups, etc.)
+      // COEP/COOP only on the video editor page — FFmpeg WASM needs SharedArrayBuffer,
+      // which requires "cross-origin isolation". We use `credentialless` instead of
+      // `require-corp` so cross-origin resources (unpkg ffmpeg-core, S3 video bytes,
+      // Google profile images) load without needing a CORP header on the response.
+      // Chromium-based browsers (Chrome, Edge, Opera) support `credentialless`;
+      // Firefox/Safari fall back to the stricter mode, but the editor page is
+      // primarily used on desktop Chrome.
       {
         source: "/:filename([^/]+\\.[^/]+)",
         headers: [
           {
             key: "Cross-Origin-Embedder-Policy",
-            value: "require-corp",
+            value: "credentialless",
           },
           {
             key: "Cross-Origin-Opener-Policy",

--- a/src/app/api/summarize/route.js
+++ b/src/app/api/summarize/route.js
@@ -2,122 +2,248 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/libs/auth";
 import { summarizeLimiter } from "@/libs/rate-limit";
 
+/**
+ * POST /api/summarize
+ * Body: { text: string }
+ * Response: { summary: string, source: 'anthropic' | 'openai' | 'hf' | 'extractive' }
+ *
+ * Summarization strategy (first success wins):
+ *   1. Anthropic Claude (if ANTHROPIC_API_KEY is set) — best quality.
+ *   2. OpenAI (if OPENAI_API_KEY is set).
+ *   3. Hugging Face BART (if HF_TOKEN is set).
+ *   4. Extractive fallback — TF-IDF + positional weighting.
+ *
+ * The extractive fallback used to just pick the top 3 sentences by word
+ * frequency, which almost always surfaced the first three sentences of a
+ * transcript verbatim (because intros are dense with topic keywords).
+ * We now use a simple TF-IDF-ish score, penalize near-duplicate sentences,
+ * and sample from across the whole transcript so the summary actually
+ * reflects the full content.
+ */
 export async function POST(req) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  // Rate limit by user email
   const { success: rateLimitOk, resetIn } = summarizeLimiter(session.user.email);
   if (!rateLimitOk) {
     return Response.json(
       { error: "Too many requests. Please wait." },
-      { status: 429, headers: { 'Retry-After': String(Math.ceil(resetIn / 1000)) } }
+      { status: 429, headers: { "Retry-After": String(Math.ceil(resetIn / 1000)) } }
     );
   }
 
   try {
     const { text } = await req.json();
-
     if (!text || text.trim().length === 0) {
       return Response.json({ error: "No text provided" }, { status: 400 });
     }
 
-    // Truncate input to a reasonable length for summarization
-    const inputText = text.slice(0, 4000);
+    // Keep the input to ~8k chars; long transcripts get truncated from the
+    // middle so we preserve both the intro and outro.
+    const inputText = clampMiddle(text, 8000);
 
-    // Try Hugging Face Inference API (free, no key required for moderate usage)
-    // Falls back to extractive summarization if HF is unavailable
-    let summary;
-
-    try {
-      const hfResponse = await fetch(
-        "https://api-inference.huggingface.co/models/facebook/bart-large-cnn",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            // Optional: add HF token for higher rate limits
-            ...(process.env.HF_TOKEN ? { Authorization: `Bearer ${process.env.HF_TOKEN}` } : {}),
-          },
-          body: JSON.stringify({
-            inputs: inputText,
-            parameters: {
-              max_length: 200,
-              min_length: 40,
-              do_sample: false,
-            },
-          }),
-        }
-      );
-
-      if (hfResponse.ok) {
-        const data = await hfResponse.json();
-        summary = Array.isArray(data) ? data[0]?.summary_text : data?.summary_text;
+    // 1) Anthropic Claude
+    if (process.env.ANTHROPIC_API_KEY) {
+      try {
+        const summary = await summarizeWithAnthropic(inputText);
+        if (summary) return Response.json({ summary, source: "anthropic" });
+      } catch (e) {
+        console.warn("Anthropic summarize failed:", e?.message);
       }
-    } catch {
-      // HF unavailable — fall through to extractive fallback
     }
 
-    // Fallback: simple extractive summarization (no external API needed)
-    if (!summary) {
-      summary = extractiveSummarize(inputText);
+    // 2) OpenAI
+    if (process.env.OPENAI_API_KEY) {
+      try {
+        const summary = await summarizeWithOpenAI(inputText);
+        if (summary) return Response.json({ summary, source: "openai" });
+      } catch (e) {
+        console.warn("OpenAI summarize failed:", e?.message);
+      }
     }
 
-    return Response.json({ summary });
+    // 3) Hugging Face BART — only bother if a token is present; the free
+    // unauthenticated endpoint is rate-limited into uselessness.
+    if (process.env.HF_TOKEN) {
+      try {
+        const summary = await summarizeWithHF(inputText);
+        if (summary) return Response.json({ summary, source: "hf" });
+      } catch (e) {
+        console.warn("HF summarize failed:", e?.message);
+      }
+    }
+
+    // 4) Extractive fallback
+    const summary = extractiveSummarize(inputText);
+    return Response.json({ summary, source: "extractive" });
   } catch (error) {
     console.error("Summarization error:", error);
     return Response.json({ error: "Failed to summarize" }, { status: 500 });
   }
 }
 
+// ---------- LLM providers ----------
+
+async function summarizeWithAnthropic(text) {
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 350,
+      messages: [
+        {
+          role: "user",
+          content:
+            "Summarize this video transcript in 3-5 concise sentences. Focus on the main topic, key points, and conclusion. Do NOT just quote the opening. Respond with ONLY the summary, no preamble.\n\nTranscript:\n" +
+            text,
+        },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`Anthropic HTTP ${res.status}`);
+  const data = await res.json();
+  return data?.content?.[0]?.text?.trim() || null;
+}
+
+async function summarizeWithOpenAI(text) {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You summarize video transcripts. Produce a 3-5 sentence summary of the main topic, key points, and conclusion. Do not quote the opening verbatim.",
+        },
+        { role: "user", content: text },
+      ],
+      max_tokens: 350,
+      temperature: 0.3,
+    }),
+  });
+  if (!res.ok) throw new Error(`OpenAI HTTP ${res.status}`);
+  const data = await res.json();
+  return data?.choices?.[0]?.message?.content?.trim() || null;
+}
+
+async function summarizeWithHF(text) {
+  const res = await fetch(
+    "https://api-inference.huggingface.co/models/facebook/bart-large-cnn",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.HF_TOKEN}`,
+      },
+      body: JSON.stringify({
+        inputs: text.slice(0, 3500), // BART max ~1024 tokens
+        parameters: { max_length: 220, min_length: 60, do_sample: false },
+        options: { wait_for_model: true },
+      }),
+    }
+  );
+  if (!res.ok) throw new Error(`HF HTTP ${res.status}`);
+  const data = await res.json();
+  return (Array.isArray(data) ? data[0]?.summary_text : data?.summary_text)?.trim() || null;
+}
+
+// ---------- Helpers ----------
+
+/** Truncate long inputs by removing the middle, preserving intro + outro. */
+function clampMiddle(text, maxLen) {
+  if (text.length <= maxLen) return text;
+  const half = Math.floor(maxLen / 2) - 20;
+  return text.slice(0, half) + "\n...[transcript truncated]...\n" + text.slice(-half);
+}
+
 /**
- * Extractive summarization fallback.
- * Scores sentences by word frequency and returns the top ones.
- * No external API needed — runs entirely server-side.
+ * Extractive summarizer. Better than "top 3 by word frequency" because it:
+ *   - uses tf-idf-ish scoring (penalizes super common words),
+ *   - applies positional weighting (first/last sentences boosted slightly),
+ *   - penalizes near-duplicate sentences (Jaccard similarity),
+ *   - spreads picks across the whole transcript so you don't just get the intro.
  */
-function extractiveSummarize(text, maxSentences = 3) {
-  const sentences = text
-    .replace(/\n+/g, ' ')
+function extractiveSummarize(text, maxSentences = 4) {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const sentences = normalized
     .split(/(?<=[.!?])\s+/)
-    .filter(s => s.trim().length > 15);
+    .map((s) => s.trim())
+    .filter((s) => s.length > 20);
 
-  if (sentences.length <= maxSentences) {
-    return sentences.join(' ');
-  }
+  if (sentences.length === 0) return normalized.slice(0, 400);
+  if (sentences.length <= maxSentences) return sentences.join(" ");
 
-  // Build word frequency map (skip common stop words)
   const stopWords = new Set([
-    'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
-    'of', 'with', 'by', 'is', 'was', 'are', 'were', 'be', 'been', 'being',
-    'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
-    'should', 'may', 'might', 'shall', 'can', 'it', 'its', 'this', 'that',
-    'these', 'those', 'i', 'you', 'he', 'she', 'we', 'they', 'me', 'him',
-    'her', 'us', 'them', 'my', 'your', 'his', 'our', 'their', 'not', 'no',
-    'so', 'if', 'then', 'than', 'just', 'also', 'very', 'too', 'as', 'from',
+    "the","a","an","and","or","but","in","on","at","to","for","of","with","by",
+    "is","was","are","were","be","been","being","have","has","had","do","does",
+    "did","will","would","could","should","may","might","shall","can","it","its",
+    "this","that","these","those","i","you","he","she","we","they","me","him",
+    "her","us","them","my","your","his","our","their","not","no","so","if","then",
+    "than","just","also","very","too","as","from","about","into","out","up","down",
+    "over","under","again","more","most","some","such","only","own","same","other",
+    "yeah","okay","uh","um","like","gonna","wanna","really","know","think","one",
+    "two","get","got","go","going","come","coming","thing","things","way","ways",
+    "lot","lots","guys","guy","hey","right","well","now","here","there","where",
   ]);
 
-  const wordFreq = {};
-  const words = text.toLowerCase().match(/\b[a-z]{3,}\b/g) || [];
-  for (const w of words) {
-    if (!stopWords.has(w)) {
-      wordFreq[w] = (wordFreq[w] || 0) + 1;
-    }
-  }
+  const tokenize = (s) => (s.toLowerCase().match(/\b[a-z]{3,}\b/g) || []).filter((w) => !stopWords.has(w));
 
-  // Score each sentence by sum of its word frequencies
-  const scored = sentences.map((s, idx) => {
-    const sWords = s.toLowerCase().match(/\b[a-z]{3,}\b/g) || [];
-    const score = sWords.reduce((sum, w) => sum + (wordFreq[w] || 0), 0) / (sWords.length || 1);
-    return { sentence: s.trim(), score, idx };
+  // Document frequency (how many sentences contain each word)
+  const df = {};
+  const sentTokens = sentences.map((s) => {
+    const toks = tokenize(s);
+    const uniq = new Set(toks);
+    uniq.forEach((w) => { df[w] = (df[w] || 0) + 1; });
+    return toks;
+  });
+  const N = sentences.length;
+
+  // Score sentences by tf-idf-ish sum, normalized by length, with positional boost
+  const scored = sentences.map((sentence, idx) => {
+    const toks = sentTokens[idx];
+    if (toks.length === 0) return { sentence, score: 0, idx, tokens: new Set() };
+    const tf = {};
+    for (const w of toks) tf[w] = (tf[w] || 0) + 1;
+    let score = 0;
+    for (const [w, f] of Object.entries(tf)) {
+      const idf = Math.log(1 + N / (df[w] || 1));
+      score += f * idf;
+    }
+    score /= Math.sqrt(toks.length); // length normalization
+    // Positional weight: slight boost for first 20% and last 20%
+    const pos = idx / N;
+    if (pos < 0.2 || pos > 0.8) score *= 1.1;
+    return { sentence, score, idx, tokens: new Set(toks) };
   });
 
-  // Pick top sentences, preserving original order
-  const top = scored
-    .sort((a, b) => b.score - a.score)
-    .slice(0, maxSentences)
-    .sort((a, b) => a.idx - b.idx);
-
-  return top.map(t => t.sentence).join(' ');
+  // Greedy MMR-like selection — pick the highest-scoring sentence that isn't
+  // too similar to ones already selected.
+  const sorted = [...scored].sort((a, b) => b.score - a.score);
+  const picked = [];
+  const jaccard = (a, b) => {
+    if (a.size === 0 || b.size === 0) return 0;
+    let inter = 0;
+    for (const w of a) if (b.has(w)) inter++;
+    return inter / (a.size + b.size - inter);
+  };
+  for (const cand of sorted) {
+    if (picked.length >= maxSentences) break;
+    const tooSimilar = picked.some((p) => jaccard(p.tokens, cand.tokens) > 0.45);
+    if (!tooSimilar) picked.push(cand);
+  }
+  // Preserve original order
+  picked.sort((a, b) => a.idx - b.idx);
+  return picked.map((p) => p.sentence).join(" ");
 }

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -14,6 +14,7 @@ import axios from 'axios';
 import toast from 'react-hot-toast';
 import UploadForm from '@/components/UploadForm';
 import { DashboardSkeleton } from '@/components/Skeleton';
+import UserAvatar from '@/components/UserAvatar';
 
 export default function DashboardPage() {
   return (
@@ -103,18 +104,21 @@ function DashboardContent() {
           animate={{ opacity: 1, y: 0 }}
           className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8"
         >
-          <div>
-            <div className="flex items-center gap-3 mb-1">
-              <h1 className="text-2xl sm:text-3xl font-bold">
-                Welcome back, {session.user.name?.split(' ')[0] || 'Creator'}
-              </h1>
-              {isAdmin && (
-                <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400 uppercase tracking-wider">
-                  Admin
-                </span>
-              )}
+          <div className="flex items-center gap-4">
+            <UserAvatar user={session.user} size={52} />
+            <div>
+              <div className="flex items-center gap-3 mb-1">
+                <h1 className="text-2xl sm:text-3xl font-bold">
+                  Welcome back, {session.user.name?.split(' ')[0] || 'Creator'}
+                </h1>
+                {isAdmin && (
+                  <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-400 uppercase tracking-wider">
+                    Admin
+                  </span>
+                )}
+              </div>
+              <p className="text-white/55">Upload a video to get started with AI captions.</p>
             </div>
-            <p className="text-white/55">Upload a video to get started with AI captions.</p>
           </div>
 
           {/* Plan + usage in header area */}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -6,6 +6,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Menu, X, ChevronDown, LogOut, LayoutDashboard } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import Logo from "./Logo";
+import UserAvatar from "./UserAvatar";
 
 export default function Navbar() {
   const { data: session, status } = useSession();
@@ -62,13 +63,7 @@ export default function Navbar() {
             ) : session ? (
               <div className="relative" ref={profileRef}>
                 <button onClick={() => setProfileOpen(!profileOpen)} aria-expanded={profileOpen} aria-haspopup="menu" className="flex items-center gap-2 px-3 py-1.5 rounded-xl hover:bg-white/5 transition-colors">
-                  {session.user.image ? (
-                    <img src={session.user.image} alt="" className="w-8 h-8 rounded-full ring-2 ring-brand-500/30" />
-                  ) : (
-                    <div className="w-8 h-8 rounded-full bg-brand-600 flex items-center justify-center text-sm font-bold">
-                      {session.user.name?.[0] || 'U'}
-                    </div>
-                  )}
+                  <UserAvatar user={session.user} size={32} />
                   <ChevronDown className="w-4 h-4 text-white/50" />
                 </button>
                 <AnimatePresence>

--- a/src/components/ResultVideo.js
+++ b/src/components/ResultVideo.js
@@ -72,6 +72,7 @@ export default function ResultVideo({ filename, transcriptionItems }) {
   const [progress, setProgress] = useState(1);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isReady, setIsReady] = useState(false);
+  const [ffmpegError, setFfmpegError] = useState(null);
   const ffmpegRef = useRef(null);
   const videoRef = useRef(null);
 
@@ -103,20 +104,48 @@ export default function ResultVideo({ filename, transcriptionItems }) {
   }, [availablePresets, activePreset]);
 
   const load = async () => {
+    // Check SharedArrayBuffer up-front — ffmpeg.wasm needs cross-origin isolation
+    if (typeof SharedArrayBuffer === 'undefined') {
+      const msg = 'Your browser blocks SharedArrayBuffer (needed for video processing). Try Chrome/Edge, or disable strict privacy extensions.';
+      console.error(msg);
+      setFfmpegError(msg);
+      setIsReady(false);
+      toast.error(msg, { duration: 8000 });
+      return;
+    }
     try {
       const ffmpeg = ffmpegRef.current;
       if (!ffmpeg) return;
-      const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.2/dist/umd';
-      await ffmpeg.load({
-        coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
-        wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
-      });
+      // Try jsdelivr first (sets CORP:cross-origin by default); fall back to unpkg.
+      const sources = [
+        'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.2/dist/umd',
+        'https://unpkg.com/@ffmpeg/core@0.12.2/dist/umd',
+      ];
+      let lastErr;
+      let loaded = false;
+      for (const baseURL of sources) {
+        try {
+          const [coreURL, wasmURL] = await Promise.all([
+            toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
+            toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
+          ]);
+          await ffmpeg.load({ coreURL, wasmURL });
+          loaded = true;
+          break;
+        } catch (e) {
+          console.warn(`FFmpeg load from ${baseURL} failed:`, e);
+          lastErr = e;
+        }
+      }
+      if (!loaded) throw lastErr || new Error('All ffmpeg-core CDN sources failed');
       await ffmpeg.writeFile('/tmp/poppins.ttf', await fetchFile(poppins));
       await ffmpeg.writeFile('/tmp/poppins-bold.ttf', await fetchFile(poppinsBold));
     } catch (error) {
       console.error('Failed to load FFmpeg:', error);
+      const msg = error?.message || 'Failed to load video processor.';
+      setFfmpegError(msg);
       setIsReady(false);
-      toast.error('Failed to load video processor. Try refreshing the page.');
+      toast.error(`Video processor failed to load: ${msg}`, { duration: 8000 });
       return;
     }
     setIsReady(true);
@@ -351,6 +380,8 @@ export default function ResultVideo({ filename, transcriptionItems }) {
         <button data-action="apply-captions" onClick={transcode} disabled={isProcessing || !isReady} className={`btn-primary flex-1 justify-center ${!isReady && !isProcessing ? 'opacity-50' : ''}`}>
           {isProcessing ? (
             <FramePhaseLoader variant="inline" message="Processing..." />
+          ) : ffmpegError ? (
+            <span className="text-red-300">Processor unavailable — refresh</span>
           ) : !isReady ? (
             <FramePhaseLoader variant="inline" message="Loading FFmpeg..." />
           ) : (

--- a/src/components/UserAvatar.js
+++ b/src/components/UserAvatar.js
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Consistent user avatar used across the app (navbar, dashboard, etc.)
+ *
+ * Logic:
+ *   1. If the user has an image and it loads successfully → show the image.
+ *   2. Otherwise (no image, or image failed to load due to COEP, network,
+ *      or Google returning 404) → show a colored initial fallback.
+ *
+ * Using a state-based fallback means every surface in the app renders the
+ * exact same avatar for the same user, regardless of whether Google's
+ * profile image happens to be blocked on that particular page.
+ */
+export default function UserAvatar({ user, size = 32, ring = true, className = '' }) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const initial = (user?.name || user?.email || 'U').trim()[0]?.toUpperCase() || 'U';
+  const showImage = user?.image && !imgFailed;
+  const px = `${size}px`;
+
+  const base = `rounded-full flex items-center justify-center overflow-hidden flex-shrink-0 ${
+    ring ? 'ring-2 ring-brand-500/30' : ''
+  } ${className}`;
+
+  if (showImage) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={user.image}
+        alt={user.name || 'Profile'}
+        onError={() => setImgFailed(true)}
+        referrerPolicy="no-referrer"
+        className={base}
+        style={{ width: px, height: px }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${base} bg-brand-600 text-white font-bold`}
+      style={{ width: px, height: px, fontSize: `${Math.round(size * 0.45)}px` }}
+      aria-label={user?.name || 'User'}
+    >
+      {initial}
+    </div>
+  );
+}


### PR DESCRIPTION
- Switch editor COEP to `credentialless` so ffmpeg-core (unpkg/jsdelivr) and Google profile images load on the editor page without needing CORP headers. This was the root cause of the "Loading FFmpeg..." button being stuck.
- Add jsdelivr fallback for ffmpeg-core, detect missing SharedArrayBuffer up-front, and show an actionable error state on the Apply Captions button instead of an infinite spinner.
- New UserAvatar component with image-error fallback to initials; used in both the navbar and the dashboard welcome header so the same user renders the same avatar everywhere.
- Rewrite /api/summarize: try Anthropic → OpenAI → HF → improved extractive fallback (tf-idf + MMR de-dup + positional weighting). The old fallback just returned the first 3 transcript sentences verbatim.